### PR TITLE
chore: upgrade Rust toolchain to 1.94.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.94.0"
 profile = "default"


### PR DESCRIPTION
## Summary
- Upgrade Rust toolchain from 1.91.1 to 1.94.0
- Prepares for iceberg-rust 0.9.0 which requires MSRV 1.92.0

Stacks on:
- [x] https://github.com/block/bergr/pull/17
  - just upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)